### PR TITLE
be able to pass undefined or null as mapStateToProps (unsubscribe from redux store)

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -42,16 +42,12 @@ class App extends Component {
   }
 }
 
-function mapStateToProps(state) {
-  return {};
-}
-
 function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(Actions, dispatch)
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(App);
+export default connect(null, mapDispatchToProps)(App);
 
 // export default withStyles(styles)(App);


### PR DESCRIPTION
Thanks for sharing, If you don't want to subscribe to store updates, pass null or undefined in place of mapStateToProps.
```
export default connect(null, mapDispatchToProps)(app);
```